### PR TITLE
feat(twitter): add action presets

### DIFF
--- a/npi/browser_app/twitter/schema.py
+++ b/npi/browser_app/twitter/schema.py
@@ -1,3 +1,4 @@
+from typing import Literal
 from pydantic import Field
 from npi.types import Parameters
 
@@ -8,3 +9,19 @@ class GetTweetsParameters(Parameters):
 
 class OpenTweetParameters(Parameters):
     url: str = Field(description='URL of the tweet you want to open.')
+
+
+class SearchParameters(Parameters):
+    query: str = Field(description='Twitter search query')
+    sort_by: Literal['hottest', 'latest'] = Field(
+        default='hottest', description='Sort results by this parameter. Default is "hottest"'
+    )
+
+
+class GotoProfileParameters(Parameters):
+    username: str = Field(description='Twitter username')
+
+
+class ReplyParameters(Parameters):
+    url: str = Field(description='URL of the tweet you want to reply')
+    content: str = Field(description='Reply content')


### PR DESCRIPTION
This PR added the following Twitter action presets to reduce operation count:

1. Open a user's profile page
2. Open the notifications page
3. Search for tweets (supports sorting the results by 'hottest' or 'latest'
4. Reply to a tweet
